### PR TITLE
19 add handling for azure 503 status code

### DIFF
--- a/TfGM-API-Wrapper-iOS/Shared/ContentView.swift
+++ b/TfGM-API-Wrapper-iOS/Shared/ContentView.swift
@@ -29,6 +29,14 @@ struct ContentView: View {
                         StopCell(stop: stop).environmentObject(favouritesStore)
                     }
                     
+                    if (searchResults.count == 0){
+                        HStack{
+                            Spacer()
+                            Text("Service infomration is currently unavailable")
+                            Spacer()
+                        }
+                    }
+                    
                     HStack{
                         Spacer()
                         Text("\(searchResults.count) Stops Found")

--- a/TfGM-API-Wrapper-iOS/Shared/ServicesRequest.swift
+++ b/TfGM-API-Wrapper-iOS/Shared/ServicesRequest.swift
@@ -15,7 +15,12 @@ class ServicesRequest: ObservableObject {
             print("Invalid url...")
             return FormattedServices(destinations: [:], messages: [])
         }
-        let (data, _) = try await URLSession.shared.data(from: url)
+        let (data, response) = try await URLSession.shared.data(from: url)
+        if let httpResponse = response as? HTTPURLResponse {
+            if httpResponse.statusCode != 200{
+                return FormattedServices(destinations: [:], messages: [])
+            }
+        }
         return try! JSONDecoder().decode(FormattedServices.self, from: data)
     }
 }

--- a/TfGM-API-Wrapper-iOS/Shared/ServicesView.swift
+++ b/TfGM-API-Wrapper-iOS/Shared/ServicesView.swift
@@ -34,6 +34,23 @@ struct ServicesView: View {
                         Spacer()
                     }
                 }
+                
+                if(self.viewModel.services.destinations.count == 0){
+                    VStack {
+                        HStack {
+                            Spacer()
+                            Text("No Service information available")
+                            Spacer()
+                        }.padding()
+
+                        HStack {
+                            Spacer()
+                            Link("Please check TfGM.com for first and last tram times", destination: URL(string: "https://tfgm.com/public-transport/tram/tram-schedule")!)
+                            Spacer()
+                        }.padding()
+                    }
+                    
+                }
                 HStack {
                     Spacer()
                     Text("Contains Transport for Greater Manchester data")

--- a/TfGM-API-Wrapper-iOS/Shared/StopRequest.swift
+++ b/TfGM-API-Wrapper-iOS/Shared/StopRequest.swift
@@ -18,10 +18,8 @@ class StopRequest: ObservableObject {
         URLSession.shared.dataTask(with: url) { data, response, error in
             DispatchQueue.main.async {
                 if let httpResponse = response as? HTTPURLResponse {
-                    
                     if httpResponse.statusCode != 200{
                         return
-                        
                     }
                 }
                 let stops = try! JSONDecoder().decode([Stop].self, from: data!)

--- a/TfGM-API-Wrapper-iOS/Shared/StopRequest.swift
+++ b/TfGM-API-Wrapper-iOS/Shared/StopRequest.swift
@@ -11,16 +11,24 @@ class StopRequest: ObservableObject {
     @Published var stops = [Stop]()
     
     func requestStops(completion:@escaping ([Stop]) -> ()) {
-            guard let url = URL(string: "https://dccompsci-tfgm-api-wrapper.azurewebsites.net/api/stops") else {
-                print("Invalid url...")
-                return
-            }
-            URLSession.shared.dataTask(with: url) { data, response, error in
-                let stops = try! JSONDecoder().decode([Stop].self, from: data!)
-                DispatchQueue.main.async {
-                    completion(stops)
-                }
-            }.resume()
-            
+        guard let url = URL(string: "https://dccompsci-tfgm-api-wrapper.azurewebsites.net/api/stops") else {
+            print("Invalid url...")
+            return
         }
+        URLSession.shared.dataTask(with: url) { data, response, error in
+            DispatchQueue.main.async {
+                if let httpResponse = response as? HTTPURLResponse {
+                    
+                    if httpResponse.statusCode != 200{
+                        return
+                        
+                    }
+                }
+                let stops = try! JSONDecoder().decode([Stop].self, from: data!)
+                
+                completion(stops)
+            }
+        }.resume()
+        
+    }
 }


### PR DESCRIPTION
Add handling for if the azure web service goes down.

This checks the status code is a 200 to proceed. If not, a message displaying that no live service information is available is displayed. 