### PR TITLE
fix: make stops on ios refreshable.

### DIFF
--- a/LiveTramsMCR/Shared/ContentView.swift
+++ b/LiveTramsMCR/Shared/ContentView.swift
@@ -76,6 +76,11 @@ struct ContentView: View {
                 
                 
             }
+            .refreshable {
+                StopRequest().requestStops { (stops) in
+                    self.stops = stops
+                }
+            }
         }
     }
     


### PR DESCRIPTION
This updates the stops list using the .refreshable method. 

The stops are updated using the same method as to that used to retrieve them in .onAppear

Using .refreshable doesnt appear to be supported in watchOS, so this has only been added to the iOS version