### PR TITLE
Fix lowercase search issue

### DIFF
--- a/LiveTramsMCR/Shared/Views/Home.swift
+++ b/LiveTramsMCR/Shared/Views/Home.swift
@@ -216,7 +216,7 @@ struct Home: View {
         if searchText.isEmpty {
             return self.stopViewModel.stops
         } else {
-            return self.stopViewModel.stops.filter { $0.stopName.contains(searchText)}
+            return self.stopViewModel.stops.filter { $0.stopName.lowercased().contains(searchText.lowercased())}
         }
     }
     


### PR DESCRIPTION
When users did not have the first letter being typed capitalised, the search function did not work as it directly matched the string. This now converts both the input and stop name to lower case.